### PR TITLE
Fix windows bug with JSON strings in ENV

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -19,7 +19,8 @@ if (!fs.existsSync(path.join(process.cwd(), 'config.json'))) {
 const config = require('../config.json');
 const envFilePath = path.join(process.cwd(), '.env');
 // Take config Stringify it and base64 encode it
-const configString = JSON.stringify(config);
+
+const configBase64 = Buffer.from(JSON.stringify(config)).toString('base64');
 
 const variableName = 'CONFIG';
 
@@ -33,7 +34,7 @@ fs.readFile(envFilePath, 'utf8', (err, data) => {
   // Update the value of the variable or add it if it doesn't exist
   const updatedData = data.replace(
     new RegExp(`${variableName}=(.*)`),
-    `${variableName}="${configString}"`,
+    `${variableName}="${configBase64}"`,
   );
 
   // Write the updated content back to the .env file

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,7 +4,8 @@ dotenv.config();
 import configSchema from '../schemas/config';
 
 export function loadConfig() {
-  return configSchema.parse(JSON.parse(process.env.CONFIG || '{}'));
+  const decodedData = atob(process.env.CONFIG);
+  return configSchema.parse(JSON.parse(decodedData || '{}'));
 }
 
 const config = loadConfig();


### PR DESCRIPTION
Turns out just throwing a JSON sting into ENV in Windows causes alot of issues so I am rolling back the base64 encoded config